### PR TITLE
chore: Sum of the sizes of files with the same name

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,16 +49,16 @@ jobs:
         with:
           label: custom-hash-patten
           dir: ./main/scripts/
-          hash-pattern: \-([a-z])+\.
-          hash-placeholder: -[hash].
+          hash-pattern: '\-([a-z])+\.'
+          hash-placeholder: '-[hash].'
           sha: ${{ github.event.pull_request.base.sha }}
 
       - uses: ./build-size/cache
         with:
           label: same-file-name
           dir: ./build-size/utils
-          hash-pattern: (Sizes|SizeDiffReport|SnapshotMeta)
-          hash-placeholder: [hash]
+          hash-pattern: '(Sizes|SizeDiffReport|SnapshotMeta)'
+          hash-placeholder: '[hash]'
           sha: ${{ github.event.pull_request.base.sha }}
 
   build-size-report:
@@ -103,15 +103,15 @@ jobs:
         with:
           label: custom-hash-patten
           dir: ./scripts
-          hash-pattern: \-([a-z])+\.
-          hash-placeholder: -[hash].
+          hash-pattern: '\-([a-z])+\.'
+          hash-placeholder: '-[hash].'
 
       - uses: ./build-size/report
         with:
           label: same-file-name
           dir: ./build-size/utils
-          hash-pattern: (Sizes|SizeDiffReport|SnapshotMeta)
-          hash-placeholder: [hash]
+          hash-pattern: '(Sizes|SizeDiffReport|SnapshotMeta)'
+          hash-placeholder: '[hash]'
 
   build-size-limit:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Test build-size-limit') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,12 +53,14 @@ jobs:
           hash-placeholder: '-[hash].'
           sha: ${{ github.event.pull_request.base.sha }}
 
-      - uses: ./build-size/cache
+      - run: |
+          mkdir ./build-size/test-same-file-name
+          echo 'test' >> ./build-size/test-same-file-name/index.335dae46.js
+          echo 'test' >> ./build-size/test-same-file-name/index.adeb62af.js
+      - uses: ./build-size/report
         with:
           label: same-file-name
-          dir: ./build-size/utils
-          hash-pattern: '(Sizes|SizeDiffReport|SnapshotMeta)'
-          hash-placeholder: '[hash]'
+          dir: ./build-size/test-same-file-name
           sha: ${{ github.event.pull_request.base.sha }}
 
   build-size-report:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,10 +106,14 @@ jobs:
           hash-pattern: '\-([a-z])+\.'
           hash-placeholder: '-[hash].'
 
+      - run: |
+          mkdir ./build-size/test-same-file-name
+          echo 'test' >> ./build-size/test-same-file-name/index.123.txt
+          echo 'test' >> ./build-size/test-same-file-name/index.456.txt
       - uses: ./build-size/report
         with:
           label: same-file-name
-          dir: ./build-size/utils
+          dir: ./build-size/test-same-file-name
 
   build-size-limit:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Test build-size-limit') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,8 +108,8 @@ jobs:
 
       - run: |
           mkdir ./build-size/test-same-file-name
-          echo 'test' >> ./build-size/test-same-file-name/index.abc123.js
-          echo 'test' >> ./build-size/test-same-file-name/index.abc456.js
+          echo 'test' >> ./build-size/test-same-file-name/index.335dae46.js
+          echo 'test' >> ./build-size/test-same-file-name/index.adeb62af.js
       - uses: ./build-size/report
         with:
           label: same-file-name

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,8 +108,8 @@ jobs:
 
       - run: |
           mkdir ./build-size/test-same-file-name
-          echo 'test' >> ./build-size/test-same-file-name/index.123.js
-          echo 'test' >> ./build-size/test-same-file-name/index.456.js
+          echo 'test' >> ./build-size/test-same-file-name/index.abc123.js
+          echo 'test' >> ./build-size/test-same-file-name/index.abc456.js
       - uses: ./build-size/report
         with:
           label: same-file-name

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,14 @@ jobs:
           hash-placeholder: -[hash].
           sha: ${{ github.event.pull_request.base.sha }}
 
+      - uses: ./build-size/cache
+        with:
+          label: same-file-name
+          dir: ./build-size/utils
+          hash-pattern: (Sizes|SizeDiffReport|SnapshotMeta)
+          hash-placeholder: [hash]
+          sha: ${{ github.event.pull_request.base.sha }}
+
   build-size-report:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Test build-size') }}
     needs:
@@ -97,6 +105,13 @@ jobs:
           dir: ./scripts
           hash-pattern: \-([a-z])+\.
           hash-placeholder: -[hash].
+
+      - uses: ./build-size/report
+        with:
+          label: same-file-name
+          dir: ./build-size/utils
+          hash-pattern: (Sizes|SizeDiffReport|SnapshotMeta)
+          hash-placeholder: [hash]
 
   build-size-limit:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Test build-size-limit') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,8 +108,8 @@ jobs:
 
       - run: |
           mkdir ./build-size/test-same-file-name
-          echo 'test' >> ./build-size/test-same-file-name/index.123.txt
-          echo 'test' >> ./build-size/test-same-file-name/index.456.txt
+          echo 'test' >> ./build-size/test-same-file-name/index.123.js
+          echo 'test' >> ./build-size/test-same-file-name/index.456.js
       - uses: ./build-size/report
         with:
           label: same-file-name

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           label: custom-hash-patten
           dir: ./scripts
-          hash-pattern: '\-([a-z])+\.'
+          hash-pattern: '\\-([a-z])+\\.'
           hash-placeholder: '-[hash].'
 
       - run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           label: custom-hash-patten
           dir: ./scripts
-          hash-pattern: '\\-([a-z])+\\.'
+          hash-pattern: '\-([a-z])+\.'
           hash-placeholder: '-[hash].'
 
       - run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,8 +110,6 @@ jobs:
         with:
           label: same-file-name
           dir: ./build-size/utils
-          hash-pattern: '(Sizes|SizeDiffReport|SnapshotMeta)'
-          hash-placeholder: '[hash]'
 
   build-size-limit:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Test build-size-limit') }}

--- a/build-size/cache/action.yml
+++ b/build-size/cache/action.yml
@@ -8,7 +8,7 @@ inputs:
 
   hash-pattern:
     required: true
-    default: '\\.([a-f0-9])+\\.'
+    default: '\.([a-f0-9])+\.'
     description: 'regex pattern to detect hash part of file name'
 
   hash-placeholder:

--- a/build-size/cache/action.yml
+++ b/build-size/cache/action.yml
@@ -8,7 +8,7 @@ inputs:
 
   hash-pattern:
     required: true
-    default: '/.([a-f0-9])+./'
+    default: '\\.([a-f0-9])+\\.'
     description: 'regex pattern to detect hash part of file name'
 
   hash-placeholder:

--- a/build-size/cache/dist/index.js
+++ b/build-size/cache/dist/index.js
@@ -63481,7 +63481,8 @@ async function getBuildSizes(dir2, options) {
     if (!isValidFile(filename))
       continue;
     const key = getFileNameKey(filename, buildPath, options);
-    sizes[key] = await computeFileSize(filename);
+    const fileSize = await computeFileSize(filename);
+    sizes[key] = (sizes[key] || 0) + fileSize;
   }
   (0, import_core.info)(`Computed file sizes:
 ${JSON.stringify(sizes, null, 2)}`);

--- a/build-size/report/action.yml
+++ b/build-size/report/action.yml
@@ -8,7 +8,7 @@ inputs:
 
   hash-pattern:
     required: false
-    default: '/.([a-f0-9])+./'
+    default: '\\.([a-f0-9])+\\.'
     description: 'regex pattern to detect hash part of file name'
 
   hash-placeholder:

--- a/build-size/report/action.yml
+++ b/build-size/report/action.yml
@@ -8,7 +8,7 @@ inputs:
 
   hash-pattern:
     required: false
-    default: '\\.([a-f0-9])+\\.'
+    default: '\.([a-f0-9])+\.'
     description: 'regex pattern to detect hash part of file name'
 
   hash-placeholder:

--- a/build-size/report/dist/index.js
+++ b/build-size/report/dist/index.js
@@ -66232,7 +66232,8 @@ async function getBuildSizes(dir2, options) {
     if (!isValidFile(filename))
       continue;
     const key = getFileNameKey(filename, buildPath, options);
-    sizes[key] = await computeFileSize(filename);
+    const fileSize = await computeFileSize(filename);
+    sizes[key] = (sizes[key] || 0) + fileSize;
   }
   (0, import_core2.info)(`Computed file sizes:
 ${JSON.stringify(sizes, null, 2)}`);

--- a/build-size/utils/BuildSizes.ts
+++ b/build-size/utils/BuildSizes.ts
@@ -58,7 +58,9 @@ export async function getBuildSizes(
   for await (const filename of globber.globGenerator()) {
     if (!isValidFile(filename)) continue;
     const key = getFileNameKey(filename, buildPath, options);
-    sizes[key] = await computeFileSize(filename);
+    const fileSize = await computeFileSize(filename);
+    //index.[hash].js - 300KB, index.[hash].js - 0.3KB -> index.[hash].js - 300.3KB
+    sizes[key] = (sizes[key] || 0) + fileSize;
   }
 
   info(`Computed file sizes:\n${JSON.stringify(sizes, null, 2)}`);


### PR DESCRIPTION
Sometimes projects generate files with the same name but different hashes -> `index.123.js`, `index.456.js`. And build-size action can calculate the size of different files each time and mess report. And to prevent it we can sum the size of files.
@doniyor2109 What do you think about this approach?
<img width="391" alt="Screenshot 2022-12-29 at 10 39 11" src="https://user-images.githubusercontent.com/4053068/209910538-e02eb65c-ef97-43ae-8ffc-59a64d1fceea.png">
<img width="305" alt="Screenshot 2022-12-29 at 10 39 29" src="https://user-images.githubusercontent.com/4053068/209910554-2ac6803e-297e-4f1c-b3b4-b48c8a646ccd.png">
